### PR TITLE
feat(show): hide update packages

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
       '@types/pacote': ^11.1.0
       '@types/semver': ^7.3.1
       '@types/yargs': ^15.0.5
-      '@typescript-eslint/eslint-plugin': ^3.8.0
+      '@typescript-eslint/eslint-plugin': ^3.9.0
       ava: ^3.11.1
       chalk: ^4.1.0
       cli-progress: ^3.8.2

--- a/src/api/check.ts
+++ b/src/api/check.ts
@@ -12,7 +12,7 @@ export interface CheckEventCallbacks {
   onDependencyResolved?: DependencyResolvedCallback
 }
 
-export async function CheckPackages(options: CheckOptions, tableLogger: TableLogger, callbacks: CheckEventCallbacks = {}) {
+export async function CheckPackages(options: CheckOptions, callbacks: CheckEventCallbacks = {}) {
   // packages loading
   const packages = await loadPackages(options)
   callbacks.afterPackagesLoaded?.(packages)

--- a/src/api/check.ts
+++ b/src/api/check.ts
@@ -1,7 +1,6 @@
 import { CheckOptions, RawDependency, PackageMeta, DependencyFilter, RangeMode, DependencyResolvedCallback } from '../types'
 import { loadPackages, writePackage } from '../io/packages'
 import { resolvePackage } from '../io/resolves'
-import { TableLogger } from '../log'
 export interface CheckEventCallbacks {
   afterPackagesLoaded?: (pkgs: PackageMeta[]) => void
   beforePackageStart?: (pkg: PackageMeta) => void

--- a/src/api/check.ts
+++ b/src/api/check.ts
@@ -4,7 +4,7 @@ import { resolvePackage } from '../io/resolves'
 export interface CheckEventCallbacks {
   afterPackagesLoaded?: (pkgs: PackageMeta[]) => void
   beforePackageStart?: (pkg: PackageMeta) => void
-  afterPackageEnd?: (pkg: PackageMeta) => boolean
+  afterPackageEnd?: (pkg: PackageMeta) => void
   beforePackageWrite?: (pkg: PackageMeta) => boolean | Promise<boolean>
   afterPackagesEnd?: (pkgs: PackageMeta[]) => void
   afterPackageWrite?: (pkg: PackageMeta) => void

--- a/src/api/check.ts
+++ b/src/api/check.ts
@@ -35,7 +35,8 @@ export async function CheckPackages(options: CheckOptions, tableLogger: TableLog
       counter++
   }
 
-  tableLogger.log(`${chalk.green(`${counter} packages are already up-to-date`)}`)
+  if (!options.showAll)
+    tableLogger.log(`${chalk.green(`${counter} packages are already up-to-date`)}`)
 
   return {
     packages,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -96,6 +96,12 @@ yargs
           type: 'boolean',
           describe: 'exit with non-zero code if there are existing upgrades',
         })
+        .option('showAll', {
+          alias: 'a',
+          default: false,
+          type: 'boolean',
+          describe: 'show all packages up to date info',
+        })
     },
     args => check(args),
   )

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -96,7 +96,7 @@ yargs
           type: 'boolean',
           describe: 'exit with non-zero code if there are existing upgrades',
         })
-        .option('showAll', {
+        .option('all', {
           alias: 'a',
           default: false,
           type: 'boolean',

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -132,8 +132,10 @@ export function printChanges(
     const counters: Record<string, number> = {}
 
     changes.forEach(({ diff }) => {
-      if (!diff) return
-      if (!counters[diff]) counters[diff] = 0
+      if (!diff) 
+        return
+      if (!counters[diff]) 
+        counters[diff] = 0
       counters[diff] += 1
     })
 

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -44,7 +44,7 @@ export async function check(options: CheckOptions) {
       if (changes.length)
         hasChanges = true
 
-      printChanges(pkg, changes, relative, logger, options.showAll)
+      printChanges(pkg, changes, relative, logger, options.all)
     },
     afterPackagesEnd(packages) {
       if (!options.all) {

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -47,7 +47,7 @@ export async function check(options: CheckOptions) {
       printChanges(pkg, changes, relative, logger, options.showAll)
     },
     afterPackagesEnd(packages) {
-      if (!options.showAll) {
+      if (!options.all) {
         const counter = packages.reduce((counter, pkg) => {
           for (let i = 0; i < pkg.resolved.length; i++) {
             if (pkg.resolved[i].update)

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -25,7 +25,7 @@ export async function check(options: CheckOptions) {
 
   let hasChanges = false
 
-  await CheckPackages(options, logger, {
+  await CheckPackages(options, {
     afterPackagesLoaded(pkgs) {
       packagesBar = options.recursive
         ? bars.create(pkgs.length, 0, { type: chalk.cyan('pkg') })
@@ -45,8 +45,6 @@ export async function check(options: CheckOptions) {
         hasChanges = true
 
       printChanges(pkg, changes, relative, logger, options.showAll)
-
-      return changes.length > 0
     },
     afterPackagesEnd(packages) {
       if (!options.showAll) {
@@ -159,14 +157,16 @@ export function printChanges(
 
   if (errors.length) {
     logger.log()
-    for (const dep of errors) printResolveError(dep, logger)
+    for (const dep of errors)
+      printResolveError(dep, logger)
   }
 
   logger.log()
 }
 
 function printResolveError(dep: ResolvedDependencies, logger: TableLogger) {
-  if (dep.resolveError == null) return
+  if (dep.resolveError == null)
+    return
 
   if (dep.resolveError === '404') {
     logger.log(chalk.redBright(`> ${chalk.underline(dep.name)} not found`))

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -43,7 +43,7 @@ export async function check(options: CheckOptions) {
       const changes = resolved.filter(i => i.update)
       if (changes.length) hasChanges = true
 
-      printChanges(pkg, changes, relative, logger)
+      printChanges(pkg, changes, relative, logger, options.showAll)
 
       return changes.length > 0
     },
@@ -87,6 +87,7 @@ export function printChanges(
   changes: ResolvedDependencies[],
   filepath: string,
   logger: TableLogger,
+  showAll: boolean,
 ) {
   if (changes.length) {
     logger.log(`${chalk.cyan(pkg.name)} ${chalk.gray(filepath)}`)
@@ -129,6 +130,11 @@ export function printChanges(
         ),
       )
     }
+  }
+  else if (showAll) {
+    logger.log(`${chalk.cyan(pkg.name)} ${chalk.gray(filepath)}`)
+    logger.log()
+    logger.log(`${chalk.gray('  ✓ up to date')}`)
   }
 
   const errors = pkg.resolved.filter(i => i.resolveError != null)

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -41,11 +41,29 @@ export async function check(options: CheckOptions) {
 
       const { relative, resolved } = pkg
       const changes = resolved.filter(i => i.update)
-      if (changes.length) hasChanges = true
+      if (changes.length)
+        hasChanges = true
 
       printChanges(pkg, changes, relative, logger, options.showAll)
 
       return changes.length > 0
+    },
+    afterPackagesEnd(packages) {
+      if (!options.showAll) {
+        const counter = packages.reduce((counter, pkg) => {
+          for (let i = 0; i < pkg.resolved.length; i++) {
+            if (pkg.resolved[i].update)
+              return ++counter
+          }
+
+          return counter
+        }, 0)
+
+        const last = packages.length - counter
+
+        if (last > 0)
+          logger.log(`${chalk.green(`${last} packages are already up-to-date`)}`)
+      }
     },
     onDependencyResolved(pkgName, name, progress) {
       depBar.update(progress, { name })

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,7 @@ export interface UsageOptions extends CommonOptions {
 export interface CheckOptions extends CommonOptions {
   mode: string
   write: boolean
+  showAll: boolean
 }
 
 export interface PackageMeta {

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,7 @@ export interface UsageOptions extends CommonOptions {
 export interface CheckOptions extends CommonOptions {
   mode: string
   write: boolean
-  showAll: boolean
+  all: boolean
 }
 
 export interface PackageMeta {


### PR DESCRIPTION
# motivation

when run taze in Monorepo, maybe some packages is up to date, but still shown out.

I add a feature, it will auto hide the package that is up to date and show a log like below pic.

![image](https://user-images.githubusercontent.com/6065488/92089948-67ad2580-ee01-11ea-8d2f-23c8a1f85520.png)
