### PR TITLE
fix: replace `undefined` with `›`

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -106,7 +106,7 @@ export function printChanges(
   options: CheckOptions,
 ) {
   if (changes.length) {
-    logger.log(`${chalk.cyan(pkg.name)} ${chalk.gray(filepath)}`)
+    logger.log(`${chalk.cyan(pkg.name ?? '›')} ${chalk.gray(filepath)}`)
     logger.log()
 
     changes.forEach(


### PR DESCRIPTION
It is common that, in full-stack projects, a `package.json` has no `name` property because it is not relevant. In those case, `taze` displays `undefined` in place of the package name.

![](https://i.imgur.com/Ks7CgJi.png) 

This PR proposes to replace `undefined` with the `›` symbol, or any other arrow. It could also be something like "unnamed project" or something else along those lines, but I wasn't sure about that and felt like a simple symbol was the best replacement.

**Note**: I didn't test this change, I PR'd via the GitHub interface, and [I couldn't just `npx` my branch](https://i.imgur.com/KmoePuZ.png). Given the simplicity of the PR it shouldn't matter, but I suggest you check it locally before merging if you decide to do so.