### PR TITLE
feat: implement loglevel option

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,12 @@ function commonOptions(args: Argv<{}>): Argv<CommonOptions> {
       type: 'string',
       describe: 'specify the current working directory',
     })
+    .option('loglevel', {
+      default: 'error',
+      type: 'string',
+      describe: '',
+      choices: ['warn', 'error']
+    })
     .option('recursive', {
       alias: 'r',
       type: 'boolean',

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -163,20 +163,20 @@ export function printChanges(
   if (errors.length) {
     logger.log()
     for (const dep of errors)
-      printResolveError(dep, logger)
+      printResolveError(dep, logger, options)
   }
 
   logger.log()
 }
 
-function printResolveError(dep: ResolvedDependencies, logger: TableLogger) {
+function printResolveError(dep: ResolvedDependencies, logger: TableLogger, options: CheckOptions) {
   if (dep.resolveError == null)
     return
 
   if (dep.resolveError === '404') {
     logger.log(chalk.redBright(`> ${chalk.underline(dep.name)} not found`))
   }
-  else if (dep.resolveError === 'invalid_range') {
+  else if (dep.resolveError === 'invalid_range' && options.loglevel === 'warn') {
     logger.log(
       chalk.yellowBright(
         `> ${chalk.underline(

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export interface CommonOptions {
   exclude?: string | string[]
   prod?: boolean
   dev?: boolean
+  loglevel: string
 }
 
 export interface UsageOptions extends CommonOptions {


### PR DESCRIPTION
This PR implements a `loglevel` option to suppress warnings by default.
Closes #6.