### PR TITLE
fix: improve version handling

### DIFF
--- a/src/utils/versions.ts
+++ b/src/utils/versions.ts
@@ -5,7 +5,7 @@ export function getVersionRangePrefix(v: string) {
   const leadings = ['>=', '<=', '>', '<', '~', '^']
   const ver = v.trim()
 
-  if (ver === '*')
+  if (ver === '*' || ver === '')
     return '*'
   if (ver[0] === '~' || ver[0] === '^')
     return ver[0]
@@ -27,10 +27,7 @@ export function getVersionRangePrefix(v: string) {
   return null
 }
 
-export function changeVersionRange(version: string, mode: Exclude<RangeMode, 'latest'>) {
-  if (mode === 'newest')
-    return '*'
-
+export function changeVersionRange(version: string, mode: Exclude<RangeMode, 'latest'|'newest'>) {
   if (!semver.validRange(version))
     return null
 
@@ -65,15 +62,18 @@ export function getMaxSatisfying(versions: string[], current: string, mode: Rang
   if (mode === 'latest') {
     version = tags.latest
   }
+  else if (mode === 'newest') {
+    version = tags.next
+  }
+  else if (mode === 'default' && (current === '*' || current.trim() === '')) {
+    return null
+  }
   else {
     const range = changeVersionRange(current, mode)
     if (!range)
       throw new Error('invalid_range')
 
-    if (range === '*')
-      version = '*'
-    else
-      version = semver.maxSatisfying(versions, range)
+    version = semver.maxSatisfying(versions, range)
   }
 
   if (!version)

--- a/test/resolves.test.ts
+++ b/test/resolves.test.ts
@@ -15,13 +15,6 @@ const makePkg = (ver: string): RawDependency => {
 }
 
 test('resolveDependency', async() => {
-  // expect(false).toBe((await resolveDependency(makePkg('4.0.0'), 'default', filter)).update)
-  // expect(true).toBe((await resolveDependency(makePkg('4.0.0'), 'major', filter)).update)
-  // expect(true).toBe((await resolveDependency(makePkg('4.0.0'), 'minor', filter)).update)
-  // expect(true).toBe((await resolveDependency(makePkg('4.0.0'), 'patch', filter)).update)
-  // expect(true).toBe((await resolveDependency(makePkg('4.0.0'), 'latest', filter)).update)
-  // expect(false).toBe((await resolveDependency(makePkg('4.0.0'), 'newest', filter)).update)
-
   // default
   expect(false).toBe((await resolveDependency(makePkg(''), 'default', filter)).update)
   expect(false).toBe((await resolveDependency(makePkg('*'), 'default', filter)).update)

--- a/test/resolves.test.ts
+++ b/test/resolves.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from 'vitest'
+import type { DependencyFilter, RawDependency } from '../src'
+import { resolveDependency } from '../src'
+
+const filter: DependencyFilter = () => true
+
+const makePkg = (ver: string): RawDependency => {
+  const pkg: RawDependency = {
+    name: 'typescript',
+    currentVersion: ver,
+    source: 'dependencies',
+    update: true,
+  }
+  return pkg
+}
+
+test('resolveDependency', async() => {
+  // expect(false).toBe((await resolveDependency(makePkg('4.0.0'), 'default', filter)).update)
+  // expect(true).toBe((await resolveDependency(makePkg('4.0.0'), 'major', filter)).update)
+  // expect(true).toBe((await resolveDependency(makePkg('4.0.0'), 'minor', filter)).update)
+  // expect(true).toBe((await resolveDependency(makePkg('4.0.0'), 'patch', filter)).update)
+  // expect(true).toBe((await resolveDependency(makePkg('4.0.0'), 'latest', filter)).update)
+  // expect(false).toBe((await resolveDependency(makePkg('4.0.0'), 'newest', filter)).update)
+
+  // default
+  expect(false).toBe((await resolveDependency(makePkg(''), 'default', filter)).update)
+  expect(false).toBe((await resolveDependency(makePkg('*'), 'default', filter)).update)
+  expect(false).toBe((await resolveDependency(makePkg('4.0.0'), 'default', filter)).update)
+  expect(true).toBe((await resolveDependency(makePkg('^4.0.0'), 'default', filter)).update)
+  expect(true).toBe((await resolveDependency(makePkg('>4.0.0'), 'default', filter)).update)
+
+  // major
+  expect(false).toBe((await resolveDependency(makePkg(''), 'major', filter)).update)
+  expect(false).toBe((await resolveDependency(makePkg('*'), 'major', filter)).update)
+  expect(true).toBe((await resolveDependency(makePkg('4.0.0'), 'major', filter)).update)
+  expect(true).toBe((await resolveDependency(makePkg('^4.0.0'), 'major', filter)).update)
+  expect(true).toBe((await resolveDependency(makePkg('>4.0.0'), 'major', filter)).update)
+
+  // minor
+  expect(false).toBe((await resolveDependency(makePkg(''), 'minor', filter)).update)
+  expect(false).toBe((await resolveDependency(makePkg('*'), 'minor', filter)).update)
+  expect(true).toBe((await resolveDependency(makePkg('4.0.0'), 'minor', filter)).update)
+  expect(true).toBe((await resolveDependency(makePkg('^4.0.0'), 'minor', filter)).update)
+  expect(true).toBe((await resolveDependency(makePkg('>4.0.0'), 'minor', filter)).update)
+
+  // patch
+  expect(false).toBe((await resolveDependency(makePkg(''), 'patch', filter)).update)
+  expect(false).toBe((await resolveDependency(makePkg('*'), 'patch', filter)).update)
+  expect(true).toBe((await resolveDependency(makePkg('4.0.0'), 'patch', filter)).update)
+  expect(true).toBe((await resolveDependency(makePkg('^4.0.0'), 'patch', filter)).update)
+  expect(true).toBe((await resolveDependency(makePkg('>4.0.0'), 'patch', filter)).update)
+
+  // latest
+  expect(false).toBe((await resolveDependency(makePkg(''), 'latest', filter)).update)
+  expect(false).toBe((await resolveDependency(makePkg('*'), 'latest', filter)).update)
+  expect(true).toBe((await resolveDependency(makePkg('4.0.0'), 'latest', filter)).update)
+  expect(true).toBe((await resolveDependency(makePkg('^4.0.0'), 'latest', filter)).update)
+  expect(true).toBe((await resolveDependency(makePkg('>4.0.0'), 'latest', filter)).update)
+
+  // newest
+  expect(false).toBe((await resolveDependency(makePkg(''), 'newest', filter)).update)
+  expect(false).toBe((await resolveDependency(makePkg('*'), 'newest', filter)).update)
+  expect(true).toBe((await resolveDependency(makePkg('4.0.0'), 'newest', filter)).update)
+  expect(true).toBe((await resolveDependency(makePkg('^4.0.0'), 'newest', filter)).update)
+  expect(true).toBe((await resolveDependency(makePkg('>4.0.0'), 'newest', filter)).update)
+})

--- a/test/versions.test.ts
+++ b/test/versions.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest'
-import { getVersionRangePrefix } from '../src/utils/versions'
+import { getPackageData } from '../src/io/resolves'
+import { getMaxSatisfying, getVersionRangePrefix } from '../src/utils/versions'
 
 test('getVersionRange', () => {
   expect('~').toBe(getVersionRangePrefix('~1.2.3'))
@@ -14,6 +15,7 @@ test('getVersionRange', () => {
 
   // wildcard
   expect('*').toBe(getVersionRangePrefix('*'))
+  expect('*').toBe(getVersionRangePrefix(''))
 
   // invaid
   expect(null).toBe(getVersionRangePrefix('.2.23'))
@@ -23,4 +25,52 @@ test('getVersionRange', () => {
   expect('^').toBe(getVersionRangePrefix('1.x'))
   expect('^').toBe(getVersionRangePrefix('1.x.0'))
   expect('*').toBe(getVersionRangePrefix('x'))
+})
+
+test('getMaxSatisfying', async() => {
+  const { versions, tags } = await getPackageData('typescript')
+  const latest = tags.latest
+  const newest = tags.next
+
+  // default
+  expect(getMaxSatisfying(versions, '', 'default', tags)).toBeNull()
+  expect(getMaxSatisfying(versions, '*', 'default', tags)).toBeNull()
+  expect(getMaxSatisfying(versions, '4.0.0', 'default', tags)).toBeNull()
+  expect(latest).toBe(getMaxSatisfying(versions, '^4.0.0', 'default', tags)?.version)
+  expect(latest).toBe(getMaxSatisfying(versions, '>4.0.0', 'default', tags)?.version)
+
+  // major
+  expect(getMaxSatisfying(versions, '', 'major', tags)).not.toBeNull()
+  expect(getMaxSatisfying(versions, '*', 'major', tags)).not.toBeNull()
+  expect(getMaxSatisfying(versions, '4.0.0', 'major', tags)).not.toBeNull()
+  expect(latest).toBe(getMaxSatisfying(versions, '^4.0.0', 'major', tags)?.version)
+  expect(latest).toBe(getMaxSatisfying(versions, '>4.0.0', 'major', tags)?.version)
+
+  // minor
+  expect(getMaxSatisfying(versions, '', 'minor', tags)).toBeNull()
+  expect(getMaxSatisfying(versions, '*', 'minor', tags)).toBeNull()
+  expect(getMaxSatisfying(versions, '4.0.0', 'minor', tags)).not.toBeNull()
+  expect(getMaxSatisfying(versions, '^4.0.0', 'minor', tags)).not.toBeNull()
+  expect(getMaxSatisfying(versions, '>4.0.0', 'minor', tags)).not.toBeNull()
+
+  // patch
+  expect(getMaxSatisfying(versions, '', 'patch', tags)).toBeNull()
+  expect(getMaxSatisfying(versions, '*', 'patch', tags)).toBeNull()
+  expect(getMaxSatisfying(versions, '4.0.0', 'patch', tags)).not.toBeNull()
+  expect(getMaxSatisfying(versions, '^4.0.0', 'patch', tags)).not.toBeNull()
+  expect(getMaxSatisfying(versions, '>4.0.0', 'patch', tags)).not.toBeNull()
+
+  // latest
+  expect(latest).toBe(getMaxSatisfying(versions, '', 'latest', tags)?.version)
+  expect(latest).toBe(getMaxSatisfying(versions, '*', 'latest', tags)?.version)
+  expect(latest).toBe(getMaxSatisfying(versions, '4.0.0', 'latest', tags)?.version)
+  expect(latest).toBe(getMaxSatisfying(versions, '^4.0.0', 'latest', tags)?.version)
+  expect(latest).toBe(getMaxSatisfying(versions, '>4.0.0', 'latest', tags)?.version)
+
+  // newest
+  expect(newest).toBe(getMaxSatisfying(versions, '', 'newest', tags)?.version)
+  expect(newest).toBe(getMaxSatisfying(versions, '*', 'newest', tags)?.version)
+  expect(newest).toBe(getMaxSatisfying(versions, '4.0.0', 'newest', tags)?.version)
+  expect(newest).toBe(getMaxSatisfying(versions, '^4.0.0', 'newest', tags)?.version)
+  expect(newest).toBe(getMaxSatisfying(versions, '>4.0.0', 'newest', tags)?.version)
 })


### PR DESCRIPTION
#11 
try to fix these problems below
1. abend in default mode (situation of Issues 11)
2. current version has the same error in newest mode (whatever the package version is)
3. package version can be blank (same meaning of *)

Now the behavior is
if the package version is (* or blank) and in mode (default or newest), will not be updated
Hope I am right :)


