### PR TITLE
docs: add config file section

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,20 @@ taze --include lodash,webpack
 taze --include /react/ --exclude react-dom # regex is also supported
 ```
 
+### Config file
+
+With `.tazerc.json` file you can configure the same options the commands have.
+
+```json
+{
+  "exclude": [
+    "typescript"
+  ],
+  "force": true,
+  "install": true
+}
+```
+
 ## Programmatic APIs
 
 > TODO:


### PR DESCRIPTION
When working in #29 I see the repo has a `.tazerc.json` file, a feature I want but didn't know it's exists!

So I added a small section in the readme, you can freely improve, it's a bit rough. 