### PR TITLE
refactor: improve write tip for major mode

### DIFF
--- a/src/commands/check/index.ts
+++ b/src/commands/check/index.ts
@@ -105,7 +105,7 @@ export async function check(options: CheckOptions) {
       console.log(`Run ${c.cyan('taze major')} to check major updates`)
 
     if (hasChanges)
-      console.log(`Run ${c.green('taze -w')} to write package.json`)
+      console.log(`Add ${c.green('-w')} to write package.json`)
 
     console.log()
   }


### PR DESCRIPTION
This PR which fixes #38  is to improve the write tip for `major` mode. Right now when you run `taze major` the tip prints out:
```
Run taze -w to write package.json
```
Which is misleading since the `taze -w` will run the default mode. To fix this, we change it to:
```
Add -w to write package.json
```
Which will cover all modes ✅