### PR TITLE
feat: added --fail-on-outdated option #56

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,10 @@ function commonOptions(args: Argv<{}>): Argv<CommonOptions> {
       describe: 'log level',
       choices: LOGLEVELS,
     })
+    .option('failOnOutdated', {
+      type: 'boolean',
+      describe: 'exit with code 1 if outdated dependencies are found',
+    })
     .option('silent', {
       alias: 's',
       default: false,
@@ -137,8 +141,8 @@ yargs(hideBin(process.argv))
         .help()
     },
     async (args) => {
-      await check(await resolveConfig(args))
-      process.exit()
+      const exitCode = await check(await resolveConfig(args))
+      process.exit(exitCode)
     },
   )
   .showHelpOnFail(false)

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export interface CommonOptions {
   prod?: boolean
   dev?: boolean
   loglevel: string
+  failOnOutdated?: boolean
   silent?: boolean
   force?: boolean
   packageMode?: { [name: string]: PackageMode }


### PR DESCRIPTION
### Description

This PR adds the `--fail-on-outdated` option (usable both from cli and config file) that makes taze exit with code 1 when outdated dependencies are found (useful for CI use).

### Linked Issues

fixed #56 
