### PR TITLE
fix: defineConfig type error (#60)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { CommonOptions } from './types'
+import type { CheckOptions } from './types'
 
 export { resolvePackage, resolveDependencies, resolveDependency } from './io/resolves'
 export { loadPackage, loadPackages, writePackage } from './io/packages'
@@ -6,6 +6,6 @@ export { dumpDependencies, parseDependencies } from './io/dependencies'
 export { CheckPackages } from './api/check'
 export * from './types'
 
-export function defineConfig(config: Partial<CommonOptions>) {
+export function defineConfig(config: Partial<CheckOptions>) {
   return config
 }


### PR DESCRIPTION
replacing `CommonOptions` with `CheckOptions`

#60

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
> As it says in readme, all options command supported are also supported by defineConfig function.
> However the generic type of defineConfig is CommonOptions which doesn't cover all command options.

When receiving fields such as write or install, defineConfig indeed encounters type errors. I fixed this issue in this PR.

### Linked Issues
https://github.com/antfu/taze/issues/60

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
