### PR TITLE
feat: support aliased deps (`npm:`)

### DIFF
--- a/src/io/dependencies.ts
+++ b/src/io/dependencies.ts
@@ -20,7 +20,11 @@ export function dumpDependencies(deps: ResolvedDepChange[], type: DepType) {
     .filter(i => i.source === type)
     .sort((a, b) => a.name.localeCompare(b.name))
     .forEach((i) => {
-      data[i.name] = i.update ? i.targetVersion : i.currentVersion
+      const version = i.update ? i.targetVersion : i.currentVersion
+      if (i.aliasName === undefined)
+        data[i.name] = version
+      else
+        data[i.aliasName] = `npm:${i.name}${version ? `@${version}` : ''}`
     })
 
   return data

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export interface ResolvedDepChange extends RawDep {
   pkgData: PackageData
   resolveError?: Error | string | null
   interactiveChecked?: boolean
+  aliasName?: string
 }
 
 export interface CommonOptions {

--- a/test/fixtures/single/package.json
+++ b/test/fixtures/single/package.json
@@ -3,11 +3,13 @@
   "private": true,
   "dependencies": {
     "@taze/not-exists": "^4.13.19",
+    "@typescript/lib-dom": "npm:@types/web@^0.0.90",
     "axios": "git:axios/axios",
     "express": "4.12.x",
     "lodash": "^4.13.19",
     "multer": "^0.1.8",
     "react-bootstrap": "^0.22.6",
+    "sass": "npm:node-sass",
     "webpack": "~1.9.10"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description
[Aliased deps](https://docs.npmjs.com/cli/v9/using-npm/package-spec?v=true#aliases) are the recommended way to use `@types/web`.
https://www.npmjs.com/package/@types/web#installation

This PR implements support for aliased deps.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
