### PR TITLE
fix: no output error when network error

### DIFF
--- a/src/commands/check/render.ts
+++ b/src/commands/check/render.ts
@@ -131,6 +131,13 @@ function renderResolveError(dep: ResolvedDepChange) {
   return lines
 }
 
+export function outputErr(errLines: string[]) {
+  console.error(c.inverse(c.red(c.bold(' ERROR '))))
+  console.error()
+  console.error(errLines.join('\n'))
+  console.error()
+}
+
 export function renderPackages(resolvePkgs: PackageMeta[], options: CheckOptions) {
   const lines: string[] = ['']
   const errLines: string[] = []


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
No error message was printed when the request went wrong（For example, my npm CA setting is wrong）
![image](https://github.com/antfu/taze/assets/53564781/8081e9af-e3f6-4efb-a4a4-ccf387419b18)

After this PR fix, the error can be printed

![image](https://github.com/antfu/taze/assets/53564781/68dfac26-6d22-46cd-af9e-50a5bd1ff0ed)

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
