### PR TITLE
fix: loadGlobalPnpmPackage throws TypeError

### DIFF
--- a/src/commands/check/checkGlobal.ts
+++ b/src/commands/check/checkGlobal.ts
@@ -124,7 +124,7 @@ async function loadGlobalPnpmPackage(options: CheckOptions): Promise<GlobalPacka
     return []
   }
 
-  const pnpmOuts = JSON.parse(pnpmStdout) as PnpmOut[]
+  const pnpmOuts = (JSON.parse(pnpmStdout) as PnpmOut[]).filter(it => it.dependencies != null)
   const filter = createDependenciesFilter(options.include, options.exclude)
 
   const pkgMetas: GlobalPackageMeta[] = pnpmOuts.map(


### PR DESCRIPTION
Filter `pnpmOuts`

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

An error occurred while running `taze -g` with the following error message.

```
TypeError: Cannot convert undefined or null to object
    at Function.entries (<anonymous>)
    at file:///D:/scoop/persist/nvm/nodejs/v16.20.1/node_modules/taze/dist/cli.mjs:819:25
    at Array.map (<anonymous>)
    at loadGlobalPnpmPackage (file:///D:/scoop/persist/nvm/nodejs/v16.20.1/node_modules/taze/dist/cli.mjs:818:29)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Promise.all (index 1)
    at async checkGlobal (file:///D:/scoop/persist/nvm/nodejs/v16.20.1/node_modules/taze/dist/cli.mjs:749:22)
    at async Object.handler (file:///D:/scoop/persist/nvm/nodejs/v16.20.1/node_modules/taze/dist/cli.mjs:978:18)
```

The error occurs because the dependencies field is missing, because you get the following result when running `pnpm ls --global --depth=0 --json`.

```
[
  {
    "path": "C:\\Users\\simexce\\AppData\\Local\\pnpm\\global\\5",
    "private": false
  }
]
````

Therefore, the filtering operation is performed on pnpmOuts.



### Linked Issues
#63 

### Additional context

1. pnpm version is  8.8.0 .
2. taze version is 0.11.3 .
