### PR TITLE
fix: global package install on macOS with Homebrew nodejs

### DIFF
--- a/src/utils/npm.ts
+++ b/src/utils/npm.ts
@@ -27,7 +27,12 @@ async function getNpmConfig() {
     setCliOption('globalconfig', path.join(npmcliConfig.globalPrefix, 'etc', 'npmrc'))
   }
 
+  // npmcliConfig.load() would set unnecessary environment variables
+  // that would cause install global packages not to work on macOS Homebrew.
+  // so we have to do copy old environment variables to new environment
+  const oldEnv = { ...process.env }
   await npmcliConfig.load()
+  process.env = oldEnv
   return npmcliConfig.flat
 }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

`@npmcli/config` added on #51, and `npmcliConfig.load()` would set some env variables, and this behavior cannot be turned off with configuration. It will fail when installing global modules for nodejs installed with homebrew on macOS. 

And I didn't find that useful of those env, so set it back to the original env after `load()` to avoid this problem.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

#51

