### PR TITLE
feat: more sensible counter and version color

### DIFF
--- a/src/commands/check/render.ts
+++ b/src/commands/check/render.ts
@@ -10,6 +10,8 @@ import { DependenciesTypeShortMap } from '../../types'
 import { sortDepChanges } from '../../utils/sort'
 import { timeDifference } from '../../utils/time'
 import { FIG_CHECK, FIG_NO_POINTER, FIG_POINTER, FIG_UNCHECK, colorizeVersionDiff, formatTable } from '../../render'
+import { DiffColorMap } from '../../utils/diff'
+import type { DiffType } from '../../../dist'
 
 export function renderChange(change: ResolvedDepChange, interactive?: InteractiveContext) {
   const update = change.update && (!interactive || change.interactiveChecked)
@@ -73,7 +75,7 @@ export function renderChanges(
       })
     const diffEntries = Object.keys(diffCounts).length
       ? Object.entries(diffCounts)
-        .map(([key, value]) => `${c.yellow(value)} ${key}`)
+        .map(([key, value]) => `${c[DiffColorMap[key as DiffType || 'patch']](value)} ${key}`)
         .join(', ')
       : c.dim('no change')
 

--- a/src/commands/check/render.ts
+++ b/src/commands/check/render.ts
@@ -2,6 +2,7 @@ import c from 'picocolors'
 import semver from 'semver'
 import type {
   CheckOptions,
+  DiffType,
   InteractiveContext,
   PackageMeta,
   ResolvedDepChange,
@@ -11,7 +12,6 @@ import { sortDepChanges } from '../../utils/sort'
 import { timeDifference } from '../../utils/time'
 import { FIG_CHECK, FIG_NO_POINTER, FIG_POINTER, FIG_UNCHECK, colorizeVersionDiff, formatTable } from '../../render'
 import { DiffColorMap } from '../../utils/diff'
-import type { DiffType } from '../../../dist'
 
 export function renderChange(change: ResolvedDepChange, interactive?: InteractiveContext) {
   const update = change.update && (!interactive || change.interactiveChecked)

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,4 +1,7 @@
 import c from 'picocolors'
+import { SemVer } from 'semver'
+import { getDiff } from './io/resolves'
+import { DiffColorMap } from './utils/diff'
 
 export const FIG_CHECK = c.green('◉')
 export const FIG_UNCHECK = c.gray('◌')
@@ -92,14 +95,8 @@ export function colorizeVersionDiff(from: string, to: string, hightlightRange = 
   let i = partsToColor.findIndex((part, i) => part !== partsToCompare[i])
   i = i >= 0 ? i : partsToColor.length
 
-  // major = red (or any change before 1.0.0)
-  // minor = cyan
-  // patch = green
-  const color = (i === 0 || partsToColor[0] === '0')
-    ? 'red'
-    : i === 1
-      ? 'cyan'
-      : 'green'
+  const diffType = getDiff(new SemVer(from), new SemVer(to))
+  const color = DiffColorMap[diffType || 'patch']
 
   // if we are colorizing only part of the word, add a dot in the middle
   const middot = (i > 0 && i < partsToColor.length) ? '.' : ''

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
 import type { Packument } from 'pacote'
-import type semver from 'semver'
 import type { SortOption } from './utils/sort'
 
 export type RangeMode = 'default' | 'major' | 'minor' | 'patch' | 'latest' | 'newest'
@@ -20,7 +19,7 @@ export interface RawDep {
   update: boolean
 }
 
-export type DiffType = ReturnType<typeof semver['diff']> | 'error'
+export type DiffType = 'major' | 'minor' | 'patch' | 'error' | null
 
 export interface PackageData {
   tags: Record<string, string>

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -1,11 +1,14 @@
 export const DiffMap = {
   'error': -1,
   'major': 0,
-  'premajor': 1,
-  'minor': 2,
-  'preminor': 3,
-  'patch': 4,
-  'prepatch': 5,
-  'prerelease': 6,
-  '': 7,
+  'minor': 1,
+  'patch': 2,
+  '': 3,
 }
+
+export const DiffColorMap = {
+  major: 'red',
+  minor: 'cyan',
+  patch: 'green',
+  error: 'red',
+} as const


### PR DESCRIPTION
It's important to determine what `major`,`minor`,`patch` mean.

### Case 1: If major refers to the change of `x` of `x.y.z`(this is what `semver.diff` use):
<table>
<tr>
 <td>
 <td>change type
<tr>
 <td>0.3.4 -> 0.3.7
 <td>patch
<tr>
 <td>0.3.4 -> 0.4.6
 <td>minor
<tr>
 <td>0.0.3 -> 0.0.4
 <td>patch
</table>

Note: `semver.diff` has other types: `premajor, preminor, prepatch, prerelease`, e.g.:  

<img width="725" alt="image" src="https://github.com/antfu/taze/assets/13799160/dcd04572-029d-4838-a624-69b54f105740">

### Case 2: If major refers to "break the `^`"(this is what `changeVersionRange` use):
<table>
<tr>
 <td>
 <td>change type
<tr>
 <td>0.3.4 -> 0.3.7
 <td>patch
<tr>
 <td>0.3.4 -> 0.4.6
 <td>major
<tr>
 <td>0.0.3 -> 0.0.4
 <td>major
</table>

Note: `^` simply means allowing changes that do not modify the left-most non-zero version number.

### Case 3: If major refers to "any change below 1.0.0"(this is what `colorizeVersionDiff` use):
<table>
<tr>
 <td>
 <td>change type
<tr>
 <td>0.3.4 -> 0.3.7
 <td>major
<tr>
 <td>0.3.4 -> 0.4.6
 <td>major
<tr>
 <td>0.0.3 -> 0.0.4
 <td>major
</table>

`colorizeVersionDiff`:
```ts
export function colorizeVersionDiff(from: string, to: string, hightlightRange = true) {
  // ...
  // major = red (or any change before 1.0.0)
  // minor = cyan
  // patch = green
  const color = (i === 0 || partsToColor[0] === '0')
    ? 'red'
    : i === 1
      ? 'cyan'
      : 'green'
  // ...
```

Which one is more sensible?

### Solution

From the aspect of user, when I run `taze major`, I'm saying I can accept breaking change,
when I run `taze minor`, I'm saying I cannot accept breaking change but I want more features, when I run `taze patch`, I'm saying I want only fixes.

The first one I want to eliminate is `Case 1`. At first, it's not a thing users care much. Secondly, the design of `npm-semver`'s `ReleaseType` has many pitfalls, as to cause [many issues](https://github.com/npm/node-semver/issues?q=is%3Aissue+diff) about it.

Case 3 is a safer one. It's always good to use a safer one but it's a little bit conservative. And, I don't think it's a good idea to change the meanings of today's **mode**, but it's ok to change only the UI part.

So, this pr picks the `Case 2`.



