### PR TITLE
feat: make long list scrollable for interactive mode

### DIFF
--- a/src/commands/check/interactive.ts
+++ b/src/commands/check/interactive.ts
@@ -7,7 +7,7 @@ import { createControlledPromise, notNullish } from '@antfu/utils'
 import type { CheckOptions, InteractiveContext, PackageMeta, ResolvedDepChange } from '../../types'
 import { getVersionOfRange, updateTargetVersion } from '../../io/resolves'
 import { getPrefixedVersion } from '../../utils/versions'
-import { FIG_BLOCK, FIG_NO_POINTER, FIG_POINTER, colorizeVersionDiff, formatTable } from '../../render'
+import { FIG_BLOCK, FIG_NO_POINTER, FIG_POINTER, colorizeVersionDiff, createSliceRender, formatTable } from '../../render'
 import { timeDifference } from '../../utils/time'
 import { renderChanges } from './render'
 
@@ -56,19 +56,18 @@ export async function promptInteractive(pkgs: PackageMeta[], options: CheckOptio
 
     return {
       render() {
+        const sr = createSliceRender()
         const Y = (v: string) => c.bold(c.green(v))
         console.clear()
-        console.log(`${FIG_BLOCK} ${c.gray(`${Y('↑↓')} to select, ${Y('space')} to toggle, ${Y('→')} to change version`)}`)
-        console.log(`${FIG_BLOCK} ${c.gray(`${Y('enter')} to confirm, ${Y('esc')} to cancel`)}`)
-        console.log()
-
-        const lines: string[] = []
+        sr.push({ content: `${FIG_BLOCK} ${c.gray(`${Y('↑↓')} to select, ${Y('space')} to toggle, ${Y('→')} to change version`)}`, fixed: true })
+        sr.push({ content: `${FIG_BLOCK} ${c.gray(`${Y('enter')} to confirm, ${Y('esc')} to cancel`)}`, fixed: true })
+        sr.push({ content: '', fixed: true })
 
         pkgs.forEach((pkg) => {
-          lines.push(...renderChanges(pkg, options, ctx).lines)
+          sr.push(...renderChanges(pkg, options, ctx).lines.map(x => ({ content: x })))
         })
 
-        console.log(lines.join('\n'))
+        sr.render(index)
       },
       onKey(key) {
         switch (key.name) {

--- a/src/commands/check/render.ts
+++ b/src/commands/check/render.ts
@@ -91,8 +91,6 @@ export function renderChanges(
       changes.map(c => renderChange(c, interactive)),
       'LLRRRRRL',
     ))
-
-    lines.push('')
   }
   else if (options.all) {
     lines.push(`${c.cyan(pkg.name)} ${c.dim(filepath)}`)

--- a/src/commands/check/render.ts
+++ b/src/commands/check/render.ts
@@ -91,6 +91,8 @@ export function renderChanges(
       changes.map(c => renderChange(c, interactive)),
       'LLRRRRRL',
     ))
+
+    lines.push('')
   }
   else if (options.all) {
     lines.push(`${c.cyan(pkg.name)} ${c.dim(filepath)}`)

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import process from 'node:process'
 import c from 'picocolors'
 import { SemVer } from 'semver'
@@ -114,29 +115,32 @@ export function colorizeVersionDiff(from: string, to: string, hightlightRange = 
 
 interface SliceRenderLine {
   content: string
-  fixed: boolean
+  fixed?: boolean
 }
 
 export function createSliceRender() {
-  const all: SliceRenderLine[] = []
+  const buffer: SliceRenderLine[] = []
+
   return {
-    push(...lines: { content: string; fixed?: boolean }[]) {
-      for (const line of lines) {
-        all.push({
-          ...line,
-          fixed: line.fixed ?? false,
-        })
-      }
+    push(...lines: SliceRenderLine[]) {
+      buffer.push(...lines)
     },
     render(selectedDepIndex: number) {
-      let { rows: remainHeight, columns: availableWidth } = process.stdout
+      let {
+        rows: remainHeight,
+        columns: availableWidth,
+      } = process.stdout
+
+      const lines: SliceRenderLine[] = buffer.length < remainHeight - 1
+        ? buffer
+        : [...buffer, { content: c.yellow('  -- END --') }]
+
       // spare space for cursor
       remainHeight -= 1
       let i = 0
-      while (i < all.length) {
-        const curr = all[i]
+      while (i < lines.length) {
+        const curr = lines[i]
         if (curr.fixed) {
-          /* eslint-disable-next-line no-console */
           console.log(curr.content)
           remainHeight -= 1
           i++
@@ -145,7 +149,8 @@ export function createSliceRender() {
           break
         }
       }
-      const remainLines = all.slice(i)
+
+      const remainLines = lines.slice(i)
 
       // calculate focused line index from selected dep index
       let focusedLineIndex = 0
@@ -165,7 +170,7 @@ export function createSliceRender() {
         remainHeight < 1
           || remainLines.length === 0
           || remainLines.length <= remainHeight
-          || all.some(x => Math.ceil(visualLength(x.content) / availableWidth) > 1)
+          || lines.some(x => Math.ceil(visualLength(x.content) / availableWidth) > 1)
       ) {
         slice = remainLines
       }
@@ -176,7 +181,7 @@ export function createSliceRender() {
         const start = Math.max(0, b <= 0 ? f : f - b)
         slice = remainLines.slice(start, start + remainHeight)
       }
-      /* eslint-disable-next-line no-console */
+
       console.log(slice.map(x => x.content).join('\n'))
     },
   }

--- a/src/render.ts
+++ b/src/render.ts
@@ -114,25 +114,22 @@ export function colorizeVersionDiff(from: string, to: string, hightlightRange = 
 
 interface SliceRenderLine {
   content: string
-  rows: number
   fixed: boolean
 }
 
 export function createSliceRender() {
-  const { columns } = process.stdout
   const all: SliceRenderLine[] = []
   return {
     push(...lines: { content: string; fixed?: boolean }[]) {
       for (const line of lines) {
         all.push({
           ...line,
-          rows: Math.ceil(visualLength(line.content) / columns) || 1,
           fixed: line.fixed ?? false,
         })
       }
     },
     render(selectedDepIndex: number) {
-      let { rows: remainHeight } = process.stdout
+      let { rows: remainHeight, columns: availableWidth } = process.stdout
       // spare space for cursor
       remainHeight -= 1
       let i = 0
@@ -141,7 +138,7 @@ export function createSliceRender() {
         if (curr.fixed) {
           /* eslint-disable-next-line no-console */
           console.log(curr.content)
-          remainHeight -= curr.rows
+          remainHeight -= 1
           i++
         }
         else {
@@ -155,16 +152,21 @@ export function createSliceRender() {
       let depIndex = 0
       for (const line of remainLines) {
         if (line.content.includes(FIG_CHECK))
-          depIndex++
+          depIndex += 1
 
         if (depIndex === selectedDepIndex)
           break
         else
-          focusedLineIndex += line.rows
+          focusedLineIndex += 1
       }
 
       let slice: SliceRenderLine[]
-      if (remainHeight < 1 || remainLines.length === 0 || remainLines.length <= remainHeight) {
+      if (
+        remainHeight < 1
+          || remainLines.length === 0
+          || remainLines.length <= remainHeight
+          || all.some(x => Math.ceil(visualLength(x.content) / availableWidth) > 1)
+      ) {
         slice = remainLines
       }
       else {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

In interactive mode, if our terminal is too short or our deps are too many, we cannot see all deps.
When we use arrow keys to move the selection, the user experience is not good. Especially, when the selection is in the start part, everytime I move the selection, the terminal just scroll back to the bottom, and I can't see the selection anymore. So I have to drag to enlarge the terminal area. But what if our deps are so many that whole screen cannot embrace them or we just don't want to do the drag.

So I made the pr. The method I use is: only render a part of output lines if there is no enough space.

### Linked Issues
There is no issue about this now. Feel free to reject this if you consider it not appropriate.


