### PR TITLE
chore: fix flicker placeholder for dep bar

### DIFF
--- a/src/commands/check/index.ts
+++ b/src/commands/check/index.ts
@@ -29,7 +29,7 @@ export async function check(options: CheckOptions) {
     },
     beforePackageStart(pkg) {
       packagesBar?.increment(0, { name: c.cyan(pkg.name) })
-      depBar?.start(pkg.deps.length, 0, { type: c.green('dep') })
+      depBar?.start(pkg.deps.length, 0, { type: c.green('dep'), name: '' })
     },
     beforePackageWrite() {
       // disbale auto write


### PR DESCRIPTION

### Description

<img width="411" alt="image" src="https://github.com/antfu/taze/assets/13799160/a3a72ac1-e7a5-4c6f-9bf4-d8263d81680d">

Placeholder `{name}` shouldn't be visible.