### PR TITLE
feat!: support `pnpm.overrides` and `resolutions`, remove `--dev` and `--prod` cli option

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,18 +57,6 @@ function commonOptions(args: Argv<object>): Argv<CommonOptions> {
       type: 'string',
       describe: 'exclude dependencies to be checked, will override --include options',
     })
-    .option('dev', {
-      alias: 'D',
-      type: 'boolean',
-      describe: 'update only for devDependencies',
-      conflicts: ['prod'],
-    })
-    .option('prod', {
-      alias: 'P',
-      type: 'boolean',
-      describe: 'update only for dependencies',
-      conflicts: ['dev'],
-    })
 }
 
 // eslint-disable-next-line no-unused-expressions

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,8 +14,7 @@ export const DEFAULT_COMMON_OPTIONS: CommonOptions = {
   ignorePaths: '',
   include: '',
   exclude: '',
-  dev: false,
-  prod: false,
+  depFields: {},
 }
 
 export const DEFAULT_USAGE_OPTIONS: UsageOptions = {

--- a/src/io/dependencies.ts
+++ b/src/io/dependencies.ts
@@ -1,7 +1,18 @@
 import type { DepType, RawDep, ResolvedDepChange } from '../types'
 
+export function getByPath(obj: any, path: string) {
+  return path.split('.').reduce((o, i) => o?.[i], obj)
+}
+
+export function setByPath(obj: any, path: string, value: any) {
+  const keys = path.split('.')
+  const lastKey = keys.pop() as string
+  const target = keys.reduce((o, i) => o[i] = o[i] || {}, obj)
+  target[lastKey] = value
+}
+
 export function parseDependencies(pkg: any, type: DepType, shouldUpdate: (name: string) => boolean): RawDep[] {
-  return Object.entries(pkg[type] || {}).map(([name, version]) => parseDependency(name, version as string, type, shouldUpdate))
+  return Object.entries(getByPath(pkg, type) || {}).map(([name, version]) => parseDependency(name, version as string, type, shouldUpdate))
 }
 
 export function parseDependency(name: string, version: string, type: DepType, shouldUpdate: (name: string) => boolean): RawDep {

--- a/src/io/packages.ts
+++ b/src/io/packages.ts
@@ -26,8 +26,12 @@ export async function writePackage(pkg: PackageMeta, options: CommonOptions) {
     ['dependencies', !options.dev],
     ['devDependencies', !options.prod],
     ['optionalDependencies', !options.prod && !options.dev],
+    // PNPM
     ['pnpm.overrides', !options.prod && !options.dev],
+    // YARN
     ['resolutions', !options.prod && !options.dev],
+    // NPM
+    ['overrides', !options.prod && !options.dev],
   ] as const
 
   depKeys.forEach(([key, shouldWrite]) => {
@@ -67,6 +71,7 @@ export async function loadPackage(relative: string, options: CommonOptions, shou
       ...parseDependencies(raw, 'optionalDependencies', shouldUpdate),
       ...parseDependencies(raw, 'pnpm.overrides', shouldUpdate),
       ...parseDependencies(raw, 'resolutions', shouldUpdate),
+      ...parseDependencies(raw, 'overrides', shouldUpdate),
     ]
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,9 @@ export const DependenciesTypeShortMap = {
   peerDependencies: 'peer',
   optionalDependencies: 'optional',
   packageManager: 'package-manager',
+  'pnpm.overrides': 'pnpm-override',
+  resolutions: 'resolution',
+  overrides: 'override',
 }
 
 export interface RawDep {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,15 +4,16 @@ import type { SortOption } from './utils/sort'
 export type RangeMode = 'default' | 'major' | 'minor' | 'patch' | 'latest' | 'newest'
 export type PackageMode = Omit<RangeMode, 'default'> | 'ignore'
 export type DepType = 'dependencies' | 'devDependencies' | 'peerDependencies' | 'optionalDependencies' | 'packageManager' | 'pnpm.overrides' | 'resolutions' | 'overrides'
+
 export const DependenciesTypeShortMap = {
-  dependencies: '',
-  devDependencies: 'dev',
-  peerDependencies: 'peer',
-  optionalDependencies: 'optional',
-  packageManager: 'package-manager',
-  'pnpm.overrides': 'pnpm-override',
-  resolutions: 'resolution',
-  overrides: 'override',
+  'dependencies': '',
+  'devDependencies': 'dev',
+  'peerDependencies': 'peer',
+  'optionalDependencies': 'optional',
+  'packageManager': 'package-manager',
+  'pnpm.overrides': 'pnpm-overrides',
+  'resolutions': 'resolutions',
+  'overrides': 'overrides',
 }
 
 export interface RawDep {
@@ -52,12 +53,21 @@ export interface CommonOptions {
   ignorePaths?: string | string[]
   include?: string | string[]
   exclude?: string | string[]
-  prod?: boolean
-  dev?: boolean
   loglevel?: LogLevel
   failOnOutdated?: boolean
   silent?: boolean
+  /**
+   * Fields in package.json to be checked
+   * By default all fields will be checked
+   */
+  depFields?: DepFieldOptions
+  /**
+   * Bypass cache
+   */
   force?: boolean
+  /**
+   * Override bumping mode for specific dependencies
+   */
   packageMode?: { [name: string]: PackageMode }
 }
 
@@ -65,6 +75,8 @@ export interface UsageOptions extends CommonOptions {
   detail?: boolean
   recursive?: true
 }
+
+export type DepFieldOptions = Partial<Record<DepType, boolean>>
 
 export interface CheckOptions extends CommonOptions {
   mode?: RangeMode

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import type { SortOption } from './utils/sort'
 
 export type RangeMode = 'default' | 'major' | 'minor' | 'patch' | 'latest' | 'newest'
 export type PackageMode = Omit<RangeMode, 'default'> | 'ignore'
-export type DepType = 'dependencies' | 'devDependencies' | 'peerDependencies' | 'optionalDependencies' | 'packageManager' | 'pnpm.overrides' | 'resolutions'
+export type DepType = 'dependencies' | 'devDependencies' | 'peerDependencies' | 'optionalDependencies' | 'packageManager' | 'pnpm.overrides' | 'resolutions' | 'overrides'
 export const DependenciesTypeShortMap = {
   dependencies: '',
   devDependencies: 'dev',

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import type { SortOption } from './utils/sort'
 
 export type RangeMode = 'default' | 'major' | 'minor' | 'patch' | 'latest' | 'newest'
 export type PackageMode = Omit<RangeMode, 'default'> | 'ignore'
-export type DepType = 'dependencies' | 'devDependencies' | 'peerDependencies' | 'optionalDependencies' | 'packageManager'
+export type DepType = 'dependencies' | 'devDependencies' | 'peerDependencies' | 'optionalDependencies' | 'packageManager' | 'pnpm.overrides' | 'resolutions'
 export const DependenciesTypeShortMap = {
   dependencies: '',
   devDependencies: 'dev',

--- a/test/dumpDependencies.test.ts
+++ b/test/dumpDependencies.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { dumpDependencies } from '../src/io/dependencies'
+import type { DepType, ResolvedDepChange } from '../src/types'
+
+describe('dumpDependencies', () => {
+  function getPackageBySource(source: DepType) {
+    return {
+      name: '@types/semver',
+      currentVersion: '^7.3.10',
+      source,
+      update: true,
+      targetVersion: '^7.3.12',
+      diff: 'patch',
+    } as ResolvedDepChange
+  }
+
+  it('dump `dependencies` type', () => {
+    const dump = dumpDependencies([getPackageBySource('dependencies')], 'dependencies')
+    expect(dump).toMatchInlineSnapshot(`
+      {
+        "@types/semver": "^7.3.12",
+      }
+    `)
+  })
+  it('dump `devDependencies` type', () => {
+    const dump = dumpDependencies([getPackageBySource('devDependencies')], 'devDependencies')
+    expect(dump).toMatchInlineSnapshot(`
+      {
+        "@types/semver": "^7.3.12",
+      }
+    `)
+  })
+  it('dump `pnpm.overrides` type', () => {
+    const dump = dumpDependencies([getPackageBySource('pnpm.overrides')], 'pnpm.overrides')
+    expect(dump).toMatchInlineSnapshot(`
+      {
+        "@types/semver": "^7.3.12",
+      }
+    `)
+  })
+
+  it('dump `resolutions` type', () => {
+    const dump = dumpDependencies([getPackageBySource('resolutions')], 'resolutions')
+    expect(dump).toMatchInlineSnapshot(`
+      {
+        "@types/semver": "^7.3.12",
+      }
+    `)
+  })
+})

--- a/test/dumpDependencies.test.ts
+++ b/test/dumpDependencies.test.ts
@@ -47,4 +47,13 @@ describe('dumpDependencies', () => {
       }
     `)
   })
+
+  it('dump `overrides` type', () => {
+    const dump = dumpDependencies([getPackageBySource('overrides')], 'overrides')
+    expect(dump).toMatchInlineSnapshot(`
+      {
+        "@types/semver": "^7.3.12",
+      }
+    `)
+  })
 })

--- a/test/parseDependencies.test.ts
+++ b/test/parseDependencies.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import { parseDependencies } from '../src/io/dependencies'
+
+describe('parseDependencies', () => {
+  it('parse package `dependencies`', () => {
+    const myPackage = {
+      name: '@taze/package1',
+      private: true,
+      dependencies: {
+        '@taze/not-exists': '^4.13.19',
+        '@typescript/lib-dom': 'npm:@types/web@^0.0.80',
+      },
+    }
+    const result = parseDependencies(myPackage, 'dependencies', () => true)
+    expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "currentVersion": "^4.13.19",
+            "name": "@taze/not-exists",
+            "source": "dependencies",
+            "update": true,
+          },
+          {
+            "currentVersion": "npm:@types/web@^0.0.80",
+            "name": "@typescript/lib-dom",
+            "source": "dependencies",
+            "update": true,
+          },
+        ]
+      `)
+  })
+
+  it('parse package `devDependencies`', () => {
+    const myPackage = {
+      name: '@taze/package1',
+      private: true,
+      devDependencies: {
+        '@taze/not-exists': '^4.13.19',
+        '@typescript/lib-dom': 'npm:@types/web@^0.0.80',
+      },
+    }
+    const result = parseDependencies(myPackage, 'devDependencies', () => true)
+    expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "currentVersion": "^4.13.19",
+            "name": "@taze/not-exists",
+            "source": "devDependencies",
+            "update": true,
+          },
+          {
+            "currentVersion": "npm:@types/web@^0.0.80",
+            "name": "@typescript/lib-dom",
+            "source": "devDependencies",
+            "update": true,
+          },
+        ]
+      `)
+  })
+
+  it('parse package `pnpm.overrides`', () => {
+    const myPackage = {
+      name: '@taze/package1',
+      private: true,
+      pnpm: {
+        overrides: {
+          '@taze/not-exists': '^4.13.19',
+          '@typescript/lib-dom': 'npm:@types/web@^0.0.80',
+        },
+      },
+    }
+    const result = parseDependencies(myPackage, 'pnpm.overrides', () => true)
+    expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "currentVersion": "^4.13.19",
+            "name": "@taze/not-exists",
+            "source": "pnpm.overrides",
+            "update": true,
+          },
+          {
+            "currentVersion": "npm:@types/web@^0.0.80",
+            "name": "@typescript/lib-dom",
+            "source": "pnpm.overrides",
+            "update": true,
+          },
+        ]
+      `)
+  })
+})


### PR DESCRIPTION
Edit by @antfu:

Breaking change:

This PR removes the `--prod` and `--dev` cli arguments along with their config entry. As a replacement, a `depFields` option field is introduced in `taze.config.ts` with more granular control of each field to bump. 

----

closes: #70 

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Great project here! I use it for dependency updates in every project. I feel the need to automatically update `pnpm.overrides` with other dependencies. There already was an issue open for that, so I just implemented it.

What's changed:
- accessing package keys is now available for deep keys like `pnpm.overrides`
- keys `pnpm.overrides` and `resolutions` are added
- added a few tests to make sure that touched areas are not broken

I also tested a locally built package on monorepo, all worked well with the addition for overrides:

![image](https://github.com/antfu/taze/assets/13100280/fa0079e3-f10f-4b46-b65a-aa47b8bfe6e6)

