### PR TITLE
chore: improve tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dev": "cross-env DEBUG=taze:* esno ./src/cli.ts",
     "start": "esno ./src/cli.ts",
     "build": "unbuild",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc",
     "prepublishOnly": "nr build",
     "release": "bumpp && pnpm publish --no-git-checks",
     "test": "vitest"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,21 @@
 {
   "compilerOptions": {
-    "target": "es2018",
-    "lib": ["esnext"],
+    "target": "ESNext",
+    "lib": ["ESNext"],
+    "moduleDetection": "force",
     "rootDir": ".",
-    "module": "esnext",
-    "moduleResolution": "node",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "paths": {
       "taze": ["./src/index.ts"]
     },
     "resolveJsonModule": true,
     "strict": true,
     "strictNullChecks": true,
+    "noEmit": true,
     "esModuleInterop": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
     "skipDefaultLibCheck": true,
     "skipLibCheck": true
   }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This pull request includes updates to the tsconfig.json file, aligning it with modern development practices. The changes introduced are as follows:

### Changes
- `"moduleResolution": "Bundler"`: Since TypeScript 5.0, the "moduleResolution" configuration now deprecates the Node.js resolution modes ("Node" and "Node10") in favor of "Bundler". This setting is designed for compatibility with bundlers. In contrast to the Node.js resolution modes, the "Bundler" mode allows seamless usage of "imports" and "exports" without the need for file extensions on relative paths in imports.
- `"moduleDetection": "force"`: Enabling this option ensures that every non-declaration file is treated as a module, providing a more consistent and predictable module handling approach.
- `"isolatedModules": true`: TypeScript will now issue warnings for code that might not be correctly interpreted by a single-file transpilation process, helping catch potential issues early in the development process.
- `"verbatimModuleSyntax": true`: Forces type imports to be flagged with a `type` modifier. This is particularly useful for bundlers, as it signals upfront that the code won't be used as a value, allowing the bundler to exclude it from the generated JavaScript code.
- `"noEmit": true`: It was used as a flag on `typecheck` script, now it is part of tsconfig.json

