### PR TITLE
fix: interactive scroll

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -161,7 +161,7 @@ export function createSliceRender() {
       let focusedLineIndex = 0
       let depIndex = 0
       for (const line of remainLines) {
-        if (line.content.includes(FIG_CHECK))
+        if (line.content.includes(FIG_CHECK) || line.content.includes(FIG_UNCHECK))
           depIndex += 1
 
         if (depIndex === selectedDepIndex)


### PR DESCRIPTION
Sorry to make a mistake, I forget to check both ◉ and ◌ when counting deps.

This causes scroll of interactive mode to work abnormally when there are deps unchecked.