### PR TITLE
fix: support nested `resolutions` and `overrides`

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ export default defineConfig({
     'unocss': 'ignore',
     // regex starts and ends with '/'
     '/vue/': 'latest'
+  },
+  // disable checking for "overrides" package.json field
+  depFields: {
+    overrides: false
   }
 })
 ```

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export interface RawDep {
   currentVersion: string
   source: DepType
   update: boolean
+  parents?: string[]
 }
 
 export type DiffType = 'major' | 'minor' | 'patch' | 'error' | null

--- a/src/utils/package.ts
+++ b/src/utils/package.ts
@@ -1,0 +1,13 @@
+/**
+ * Parse input string like `package-1/package-2` to an array of packages
+ */
+export function parseYarnPackagePath(input: string): string[] {
+  return input.match(/(@[^\/]+\/)?([^/]+)/g) || []
+}
+
+/**
+ * Parse input string like `package-1>package-2` to an array of packages
+ */
+export function parsePnpmPackagePath(input: string): string[] {
+  return input.match(/[^>]+/g) || []
+}

--- a/test/parseDependencies.test.ts
+++ b/test/parseDependencies.test.ts
@@ -17,12 +17,14 @@ describe('parseDependencies', () => {
           {
             "currentVersion": "^4.13.19",
             "name": "@taze/not-exists",
+            "parents": [],
             "source": "dependencies",
             "update": true,
           },
           {
             "currentVersion": "npm:@types/web@^0.0.80",
             "name": "@typescript/lib-dom",
+            "parents": [],
             "source": "dependencies",
             "update": true,
           },
@@ -45,12 +47,14 @@ describe('parseDependencies', () => {
           {
             "currentVersion": "^4.13.19",
             "name": "@taze/not-exists",
+            "parents": [],
             "source": "devDependencies",
             "update": true,
           },
           {
             "currentVersion": "npm:@types/web@^0.0.80",
             "name": "@typescript/lib-dom",
+            "parents": [],
             "source": "devDependencies",
             "update": true,
           },
@@ -75,13 +79,116 @@ describe('parseDependencies', () => {
           {
             "currentVersion": "^4.13.19",
             "name": "@taze/not-exists",
+            "parents": [],
             "source": "pnpm.overrides",
             "update": true,
           },
           {
             "currentVersion": "npm:@types/web@^0.0.80",
             "name": "@typescript/lib-dom",
+            "parents": [],
             "source": "pnpm.overrides",
+            "update": true,
+          },
+        ]
+      `)
+  })
+
+  it('parse package `resolutions`', () => {
+    const myPackage = {
+      name: '@taze/package1',
+      private: true,
+      resolutions: {
+        '@taze/not-exists': '^4.13.19',
+        '@typescript/lib-dom': 'npm:@types/web@^0.0.80',
+        '@taze/pkg/@taze/nested-foo': '^1.0.0',
+        '@taze/pkg/@taze/nested-foo@2.0.0': '^1.0.0',
+      },
+    }
+    const result = parseDependencies(myPackage, 'resolutions', () => true)
+    expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "currentVersion": "^4.13.19",
+            "name": "@taze/not-exists",
+            "parents": [],
+            "source": "resolutions",
+            "update": true,
+          },
+          {
+            "currentVersion": "npm:@types/web@^0.0.80",
+            "name": "@typescript/lib-dom",
+            "parents": [],
+            "source": "resolutions",
+            "update": true,
+          },
+          {
+            "currentVersion": "^1.0.0",
+            "name": "@taze/pkg/@taze/nested-foo",
+            "parents": [],
+            "source": "resolutions",
+            "update": true,
+          },
+          {
+            "currentVersion": "^1.0.0",
+            "name": "@taze/pkg/@taze/nested-foo@2.0.0",
+            "parents": [],
+            "source": "resolutions",
+            "update": true,
+          },
+        ]
+      `)
+  })
+
+  it('parse package `overrides`', () => {
+    const myPackage = {
+      name: '@taze/package1',
+      private: true,
+      overrides: {
+        '@taze/not-exists': '^4.13.19',
+        '@typescript/lib-dom': 'npm:@types/web@^0.0.80',
+        '@taze/pkg': {
+          '@taze/nested-foo': '^1.0.0',
+          '@taze/nested-bar': {
+            '@taze/nested-lvl2': 'npm:@taze/override',
+          },
+        },
+      },
+    }
+    const result = parseDependencies(myPackage, 'overrides', () => true)
+    expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "currentVersion": "^4.13.19",
+            "name": "@taze/not-exists",
+            "parents": [],
+            "source": "overrides",
+            "update": true,
+          },
+          {
+            "currentVersion": "npm:@types/web@^0.0.80",
+            "name": "@typescript/lib-dom",
+            "parents": [],
+            "source": "overrides",
+            "update": true,
+          },
+          {
+            "currentVersion": "^1.0.0",
+            "name": "@taze/nested-foo",
+            "parents": [
+              "@taze/pkg",
+            ],
+            "source": "overrides",
+            "update": true,
+          },
+          {
+            "currentVersion": "npm:@taze/override",
+            "name": "@taze/nested-lvl2",
+            "parents": [
+              "@taze/pkg",
+              "@taze/nested-bar",
+            ],
+            "source": "overrides",
             "update": true,
           },
         ]

--- a/test/resolves.test.ts
+++ b/test/resolves.test.ts
@@ -27,6 +27,26 @@ function makeLocalPkg(ver: string): RawDep {
   return pkg
 }
 
+function makePkgForResolutions(name: string, ver: string): RawDep {
+  const pkg: RawDep = {
+    name,
+    currentVersion: ver,
+    source: 'resolutions',
+    update: true,
+  }
+  return pkg
+}
+
+function makePkgForPnpmOverrides(name: string, ver: string): RawDep {
+  const pkg: RawDep = {
+    name,
+    currentVersion: ver,
+    source: 'pnpm.overrides',
+    update: true,
+  }
+  return pkg
+}
+
 const options: CheckOptions = {
   cwd: process.cwd(),
   loglevel: 'silent',
@@ -104,6 +124,22 @@ it('resolveDependency', async () => {
   expect(false).toBe((await resolveDependency(makeLocalPkg('workspace:*'), options, filter)).update)
   const target = await resolveDependency(makeLocalPkg('1.0.0'), options, filter)
   expect(target.resolveError).not.toBeNull()
+
+  // yarn resolutions
+  expect(true).toBe((await resolveDependency(makePkgForResolutions('typescript', '^4.0.0'), options, filter)).update)
+  expect(true).toBe((await resolveDependency(makePkgForResolutions('typescript@5.0.0', '^4.0.0'), options, filter)).update)
+  expect(true).toBe((await resolveDependency(makePkgForResolutions('typescript', 'npm:typescript@^4.0.0'), options, filter)).update)
+  expect(true).toBe((await resolveDependency(makePkgForResolutions('foo/typescript', '^4.0.0'), options, filter)).update)
+  expect(true).toBe((await resolveDependency(makePkgForResolutions('foo/**/typescript', '^4.0.0'), options, filter)).update)
+  expect(true).toBe((await resolveDependency(makePkgForResolutions('**/typescript', '^4.0.0'), options, filter)).update)
+  expect(true).toBe((await resolveDependency(makePkgForResolutions('@foo/bar/typescript', '^4.0.0'), options, filter)).update)
+  expect(true).toBe((await resolveDependency(makePkgForResolutions('@foo/bar/typescript@5.1.0', '^4.0.0'), options, filter)).update)
+
+  // pnpm overrides
+  expect(true).toBe((await resolveDependency(makePkgForPnpmOverrides('typescript', '^4.0.0'), options, filter)).update)
+  expect(true).toBe((await resolveDependency(makePkgForPnpmOverrides('typescript', 'npm:typescript@^4.0.0'), options, filter)).update)
+  expect(true).toBe((await resolveDependency(makePkgForPnpmOverrides('typescript@5.0.0', '^4.0.0'), options, filter)).update)
+  expect(true).toBe((await resolveDependency(makePkgForPnpmOverrides('foo@1>typescript', '^4.0.0'), options, filter)).update)
 }, 10000)
 
 it('getDiff', () => {


### PR DESCRIPTION
### Description

Fix support for `overrides`, `pnpm.overrides` and `resolutions` by handling properly nested dependencies and package managers custom syntaxes.

#### overrides

[NPM allows you to specify a full object for **overrides** field](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#overrides). 

Fix the `"TypeError: currentVersion.startsWith is not a function"` error.

Output with the latest version:
<img width="1160" alt="1" src="https://github.com/antfu/taze/assets/10619585/bf31c31d-2cdd-4cd2-adfb-ea9666d2f2c4">

Output now:
<img width="1160" alt="2" src="https://github.com/antfu/taze/assets/10619585/e860167a-db4f-4df2-866f-abbaa40a2b8d">

#### pnpm.overrides

Fix support for [custom ">" dependency selector](https://pnpm.io/pt/next/package_json#pnpmoverrides) used to target nested dependencies.

Fix the `Invalid package name` error.

Output with the latest version:
<img width="1160" alt="3" src="https://github.com/antfu/taze/assets/10619585/a4a9ba6d-1810-4dc2-8b68-dd5c617a2cb6">

Output now:
<img width="1160" alt="4" src="https://github.com/antfu/taze/assets/10619585/f1a975de-d8f6-4ca0-8c19-b03e917307f7">

#### resolutions

Fix support for [nested resolutions custom syntax](https://classic.yarnpkg.com/en/docs/package-json#toc-resolutions) for Yarn.

Fix the `ENOENT: no such file or directory` error.

Output with the latest version:
<img width="1160" alt="5" src="https://github.com/antfu/taze/assets/10619585/ebc8aa90-6362-4fea-9cd2-1d238e45db17">

Output now:
<img width="1160" alt="6" src="https://github.com/antfu/taze/assets/10619585/fbae7bfe-0a55-4346-80ec-514be8a2b5f7">

### Linked Issues

Closes #96 

### Additional context

I also updated the README to reference the "depFields" option.