### PR TITLE
feat: `a` to select all packages in interactive mode

### DIFF
--- a/src/commands/check/interactive.ts
+++ b/src/commands/check/interactive.ts
@@ -66,7 +66,7 @@ export async function promptInteractive(pkgs: PackageMeta[], options: CheckOptio
         const Y = (v: string) => c.bold(c.green(v))
         console.clear()
         sr.push({ content: `${FIG_BLOCK} ${c.gray(`${Y('↑↓')} to select, ${Y('space')} to toggle, ${Y('→')} to change version`)}`, fixed: true })
-        sr.push({ content: `${FIG_BLOCK} ${c.gray(`${Y('enter')} to confirm, ${Y('esc')} to cancel`)}`, fixed: true })
+        sr.push({ content: `${FIG_BLOCK} ${c.gray(`${Y('enter')} to confirm, ${Y('esc')} to cancel, ${Y('a')} to select/unselect all`)}`, fixed: true })
         sr.push({ content: '', fixed: true })
 
         pkgs.forEach((pkg) => {
@@ -76,6 +76,8 @@ export async function promptInteractive(pkgs: PackageMeta[], options: CheckOptio
         sr.render(index)
       },
       onKey(key) {
+        const allInteractiveChecked = deps.every(d => d.interactiveChecked)
+
         switch (key.name) {
           case 'escape':
             process.exit()
@@ -103,6 +105,9 @@ export async function promptInteractive(pkgs: PackageMeta[], options: CheckOptio
           case 'right':
           case 'l':
             renderer = createVersionSelectRender(deps[index])
+            return true
+          case 'a':
+            deps.forEach(d => d.interactiveChecked = !allInteractiveChecked)
             return true
         }
       },


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

In interactive mode, allows users to press `a` to select/deselect all dependencies. If all dependencies are selected `a` will deselect all, otherwise it will select all.

### Linked Issues

- https://github.com/antfu/taze/issues/85

