### PR TITLE
ci(lint): use node `lts/*`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set node
         uses: actions/setup-node@v4
         with:
-          node-version: latest
+          node-version: lts/*
           cache: pnpm
 
       - name: Setup
@@ -44,7 +44,7 @@ jobs:
       - name: Set node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: lts/*
           cache: pnpm
 
       - name: Setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
         uses: pnpm/action-setup@v2
 
       - name: Set node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: latest
           cache: pnpm
 
       - name: Setup


### PR DESCRIPTION
### Description

The CI of #109 failed due to the outdated version of Node.js used to run the lint workflow. The PR updates the GitHub Action to fix that.

### Linked Issues

#109

### Additional context

N/A