### PR TITLE
fix: change the build config to bundle deps correctly, fix #111

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -7,6 +7,11 @@ export default defineBuildConfig({
   ],
   rollup: {
     inlineDependencies: true,
+    json: {
+      compact: true,
+      namedExports: false,
+      preferConst: true,
+    },
   },
   clean: true,
   declaration: true,

--- a/build.config.ts
+++ b/build.config.ts
@@ -9,8 +9,8 @@ export default defineBuildConfig({
     inlineDependencies: true,
     json: {
       compact: true,
-      namedExports: true,
-      preferConst: true,
+      namedExports: false,
+      preferConst: false,
     },
     commonjs: {
       requireReturnsDefault: 'auto',

--- a/build.config.ts
+++ b/build.config.ts
@@ -9,8 +9,11 @@ export default defineBuildConfig({
     inlineDependencies: true,
     json: {
       compact: true,
-      namedExports: false,
+      namedExports: true,
       preferConst: true,
+    },
+    commonjs: {
+      requireReturnsDefault: 'auto',
     },
     dts: {
       respectExternal: false,

--- a/build.config.ts
+++ b/build.config.ts
@@ -12,6 +12,9 @@ export default defineBuildConfig({
       namedExports: false,
       preferConst: true,
     },
+    dts: {
+      respectExternal: false,
+    },
   },
   clean: true,
   declaration: true,

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "execa": "^8.0.1",
     "picocolors": "^1.0.0",
     "prompts": "^2.4.2",
-    "semver": "^7.6.0",
     "ufo": "^1.5.3",
     "unconfig": "^0.3.13",
     "yargs": "^17.7.2"
@@ -67,6 +66,7 @@
     "npm-package-arg": "^11.0.2",
     "npm-registry-fetch": "^16.2.1",
     "rimraf": "^5.0.5",
+    "semver": "^7.6.0",
     "taze": "workspace:*",
     "typescript": "^5.4.5",
     "unbuild": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typecheck": "tsc",
     "prepublishOnly": "nr build",
     "release": "bumpp && pnpm publish --no-git-checks",
-    "test": "vitest"
+    "test": "unbuild && vitest"
   },
   "dependencies": {
     "@antfu/ni": "^0.21.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,6 @@ importers:
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
-      semver:
-        specifier: ^7.6.0
-        version: 7.6.0
       ufo:
         specifier: ^1.5.3
         version: 1.5.3
@@ -102,6 +99,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.5
+      semver:
+        specifier: ^7.6.0
+        version: 7.6.0
       taze:
         specifier: workspace:*
         version: 'link:'
@@ -3447,6 +3447,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
+    dev: true
 
   /magic-string@0.30.5:
     resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
@@ -4539,6 +4540,7 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
+    dev: true
 
   /shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -5185,6 +5187,7 @@ packages:
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+    dev: true
 
   /yaml-eslint-parser@1.2.2:
     resolution: {integrity: sha512-pEwzfsKbTrB8G3xc/sN7aw1v6A6c/pKxLAkjclnAyo5g5qOh6eL9WGu0o3cSDQZKrTNk4KL4lQSwZW+nBkANEg==}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@ import type { Argv } from 'yargs'
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 import c from 'picocolors'
-import { version } from '../package.json'
+import pkgJson from '../package.json'
 import { check } from './commands/check'
 import { usage } from './commands/usage'
 import { resolveConfig } from './config'
@@ -142,7 +142,7 @@ yargs(hideBin(process.argv))
   )
   .showHelpOnFail(false)
   .alias('h', 'help')
-  .version('version', version)
+  .version('version', pkgJson.version)
   .alias('v', 'version')
   .help()
   .argv

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,0 +1,11 @@
+import path from 'node:path'
+import { expect, it } from 'vitest'
+import { execa } from 'execa'
+
+it('taze cli should just works', async () => {
+  const binPath = path.resolve(__dirname, '../bin/taze.mjs')
+
+  const proc = await execa(process.execPath, [binPath], { stdio: 'pipe' })
+
+  expect(proc.stderr).toBe('')
+})


### PR DESCRIPTION
### Description

#111 is caused by the Rollup (`unbuild` uses Rollup under the hood) incorrectly bundling `@npmcli/config` (and its transitive dependency `cacache`, which requires its own `package.json`).

The PR provides a workaround by changing how dists are bundled. A test case has also been added to ensure the CLI itself should never crash.

### Linked Issues

#111

### Additional context

This is a workaround that works for now. I am still investigating a better solution that solves the issue once and for all.

Here are the backgrounds behind #111 and this PR:

- `@npmcli/config` requires `cacache`, and `cacache` requires its own `package.json`. This causes `@rollup/plugin-commonjs` to panic. Instead of using the correct named exports generated from `@rollup/plugin-json`, `@rollup/plugin-commonjs` try to wrap the exports with its interop code, causing `cacache` to fail.
  - Solution: change `@rollup/plugin-commonjs`'s `requireReturnsDefault` to `auto`, disable `@rollup/plugin-json`'s `namedExports` optimization.
- `@npmcli/config` also requires `semver/function/valid`. Since `@npmcli/config` is a CJS module, `require('semver/function/valid')` works just fine. However, when Rollup bundles the dist, it transforms `require('semver/function/valid')` into `import 'semver/function/valid'` which is an invalid ESM import (missing the extname, it should be `import 'semver/function/valid.js'`), causing the error of #111.
  - Solution: bundle the entire `semver` as well, preventing transitive dependency from becoming external.
  - Bundling `semver` would cause another build error, since `unbuild` includes `@types/semver` to be parsed by the rollup.
    - Solution: enable `rollup-plugin-dts`'s `respectExternal`.